### PR TITLE
Remove unnecessary geogram graphics dependencies

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -75,15 +75,6 @@ jobs:
           libboost-thread-dev \
           libglu1-mesa-dev \
           libsuitesparse-dev \
-          libxi-dev \
-          libxcursor-dev \
-          libxinerama-dev \
-          libxrandr-dev \
-          libx11-dev \
-          libxcb1-dev \
-          libxau-dev \
-          libxdmcp-dev \
-          xorg-dev \
           ccache
 
       - name: Build source distribution

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ test-command = "pytest {project}/tests -v"
 
 [tool.cibuildwheel.linux]
 manylinux-x86_64-image = "manylinux_2_28"
-before-all = "dnf install -y gmp-devel libXi-devel libXcursor-devel libXinerama-devel libXrandr-devel"
+before-all = "dnf install -y gmp-devel"
 before-build = "pip install cmake==3.29.0"
 environment = "USE_MAVX='true'"
 environment-pass = ["USE_MAVX"]


### PR DESCRIPTION
This PR removes some geogram dependencies, which I added before, but are actually not necessary (since we build without the GUI).