### PR TITLE
Add `.tetwild` PyVista accessor on PolyData

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ pytetwild = ["py.typed"]
 
 [project.optional-dependencies]
 all = ['pyvista']
-tests = ["pytest", "pyvista", "scipy<1.17.0", "meshio"]
+tests = ["pytest", "pytest-timeout", "pyvista", "scipy<1.17.0", "meshio"]
 dev = ["pre-commit"]
 
 [project.entry-points."pyvista.accessors"]
@@ -56,6 +56,11 @@ args = [
 
 [tool.pytest.ini_options]
 testpaths = 'tests'
+# Bound any single test; a hung fTetWild call (or stalled network
+# fetch) dumps a traceback and fails instead of blocking until the
+# 6h CI ceiling. signal method can interrupt the C extension on POSIX.
+timeout = 300
+timeout_method = 'signal'
 
 [tool.cibuildwheel]
 archs = ["auto64"]  # 64-bit only

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,11 @@ all = ['pyvista']
 tests = ["pytest", "pyvista", "scipy<1.17.0", "meshio"]
 dev = ["pre-commit"]
 
+[project.entry-points."pyvista.accessors"]
+# Value points at the plugin module; importing it runs the
+# ``@register_dataset_accessor`` decorator as a side effect.
+tetwild = "pytetwild._accessor"
+
 [tool.scikit-build]
 build-dir = "./build"
 editable.mode = "inplace"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,9 +58,9 @@ args = [
 testpaths = 'tests'
 # Bound any single test; a hung fTetWild call (or stalled network
 # fetch) dumps a traceback and fails instead of blocking until the
-# 6h CI ceiling. signal method can interrupt the C extension on POSIX.
+# 6h CI ceiling. Method is left to pytest-timeout: signal on POSIX
+# (can interrupt the C extension), thread on Windows (no SIGALRM).
 timeout = 300
-timeout_method = 'signal'
 
 [tool.cibuildwheel]
 archs = ["auto64"]  # 64-bit only

--- a/src/pytetwild/__init__.py
+++ b/src/pytetwild/__init__.py
@@ -2,3 +2,4 @@
 
 from ._version import __version__  # noqa: F401
 from .pytetwild import tetrahedralize, tetrahedralize_pv, tetrahedralize_csg  # noqa: F401
+from . import _accessor as _accessor

--- a/src/pytetwild/_accessor.py
+++ b/src/pytetwild/_accessor.py
@@ -1,0 +1,91 @@
+"""Register a ``.tetwild`` accessor on :class:`pyvista.PolyData`.
+
+Importing this module (which :mod:`pytetwild` does on package import)
+attaches a :class:`TetWildAccessor` so every :class:`~pyvista.PolyData`
+instance exposes the ``.tetwild`` namespace.
+
+Requires PyVista >= 0.48, which introduced ``register_dataset_accessor``.
+On older versions importing this module is a no-op.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pyvista as pv
+
+
+HAS_ACCESSOR_REGISTRY = hasattr(pv, "register_dataset_accessor")
+
+
+def _register(cls):
+    """Register ``cls`` as the ``.tetwild`` accessor when supported.
+
+    Parameters
+    ----------
+    cls : type
+        Accessor class to register.
+
+    Returns
+    -------
+    type
+        ``cls``, registered when PyVista exposes the accessor registry.
+    """
+    if HAS_ACCESSOR_REGISTRY:
+        return pv.register_dataset_accessor("tetwild", pv.PolyData)(cls)
+    return cls
+
+
+@_register
+class TetWildAccessor:
+    """Tetrahedralization accessor backed by fTetWild.
+
+    Wraps :func:`pytetwild.tetrahedralize_pv` so a user can tetrahedralize
+    a surface mesh in a single chained call::
+
+        import pyvista as pv
+        import pytetwild  # noqa: F401 — registers the ``.tetwild`` accessor
+
+        grid = pv.Icosphere(nsub=2).tetwild.tetrahedralize(edge_length_fac=0.1)
+
+    The accessor is scoped to :class:`~pyvista.PolyData` because fTetWild
+    consumes a triangulated surface. Non-triangular input is
+    auto-triangulated by the underlying function with a warning.
+
+    Parameters
+    ----------
+    mesh : pyvista.PolyData
+        Surface mesh exposing the ``.tetwild`` namespace.
+    """
+
+    def __init__(self, mesh: pv.PolyData) -> None:
+        """Bind the accessor to its parent :class:`~pyvista.PolyData`.
+
+        Parameters
+        ----------
+        mesh : pyvista.PolyData
+            Surface mesh exposing the ``.tetwild`` namespace.
+        """
+        self._mesh = mesh
+
+    def tetrahedralize(self, **kwargs: Any) -> pv.UnstructuredGrid:
+        """Tetrahedralize the surface mesh and return the volume grid.
+
+        Thin wrapper around :func:`pytetwild.tetrahedralize_pv`.
+        Forwards all keyword arguments; see that function's docstring
+        for the full parameter list (``edge_length_fac``, ``optimize``,
+        ``epsilon``, ``stop_energy``, and so on).
+
+        Parameters
+        ----------
+        **kwargs
+            Forwarded to :func:`pytetwild.tetrahedralize_pv`.
+
+        Returns
+        -------
+        pyvista.UnstructuredGrid
+            Tetrahedral volume mesh.
+        """
+        from pytetwild.pytetwild import tetrahedralize_pv
+
+        return tetrahedralize_pv(self._mesh, **kwargs)

--- a/tests/test_accessor.py
+++ b/tests/test_accessor.py
@@ -1,0 +1,57 @@
+"""Tests for the ``.tetwild`` accessor registered on :class:`pyvista.PolyData`."""
+
+from __future__ import annotations
+
+import pytest
+import pyvista as pv
+
+import pytetwild  # noqa: F401 — registers the ``.tetwild`` accessor
+from pytetwild import _accessor
+
+pytestmark = pytest.mark.skipif(
+    not _accessor.HAS_ACCESSOR_REGISTRY,
+    reason="requires pyvista >= 0.48 dataset accessor registry",
+)
+
+
+def test_accessor_attached_on_polydata():
+    assert hasattr(pv.Sphere(), "tetwild")
+
+
+def test_accessor_not_attached_on_non_polydata():
+    assert not hasattr(pv.ImageData(), "tetwild")
+    assert not hasattr(pv.UnstructuredGrid(), "tetwild")
+
+
+def test_accessor_cached_per_instance():
+    sphere = pv.Icosphere(nsub=1)
+    assert sphere.tetwild is sphere.tetwild
+
+
+def test_tetrahedralize_returns_unstructured_grid():
+    grid = pv.Icosphere(nsub=1).tetwild.tetrahedralize(edge_length_fac=1.0)
+    assert isinstance(grid, pv.UnstructuredGrid)
+    assert grid.n_cells > 0
+    assert grid.n_points > 0
+
+
+def test_tetrahedralize_matches_direct_api():
+    direct = pytetwild.tetrahedralize_pv(pv.Icosphere(nsub=1), edge_length_fac=1.0)
+    via_accessor = pv.Icosphere(nsub=1).tetwild.tetrahedralize(edge_length_fac=1.0)
+    assert direct.n_cells == via_accessor.n_cells
+    assert direct.n_points == via_accessor.n_points
+
+
+def test_chains_with_core_filters():
+    """Accessor result chains cleanly with a core PyVista filter."""
+    grid = pv.Icosphere(nsub=1).tetwild.tetrahedralize(edge_length_fac=1.0).extract_cells([0])
+    assert isinstance(grid, pv.UnstructuredGrid)
+    assert grid.n_cells == 1
+
+
+def test_registered_record_reports_pytetwild_as_source():
+    records = [r for r in pv.registered_accessors() if r.name == "tetwild"]
+    assert len(records) == 1
+    record = records[0]
+    assert record.target is pv.PolyData
+    assert record.source.startswith("pytetwild._accessor")

--- a/tests/test_accessor.py
+++ b/tests/test_accessor.py
@@ -35,11 +35,30 @@ def test_tetrahedralize_returns_unstructured_grid():
     assert grid.n_points > 0
 
 
-def test_tetrahedralize_matches_direct_api():
-    direct = pytetwild.tetrahedralize_pv(pv.Icosphere(nsub=1), edge_length_fac=1.0)
-    via_accessor = pv.Icosphere(nsub=1).tetwild.tetrahedralize(edge_length_fac=1.0)
-    assert direct.n_cells == via_accessor.n_cells
-    assert direct.n_points == via_accessor.n_points
+def test_tetrahedralize_delegates_to_tetrahedralize_pv(monkeypatch):
+    """Accessor forwards the parent mesh and kwargs to ``tetrahedralize_pv``.
+
+    fTetWild is non-deterministic across independent runs, so comparing
+    cell/point counts of two separate calls is unreliable. The accessor's
+    contract is delegation, which is what this asserts.
+    """
+    sphere = pv.Icosphere(nsub=1)
+    sentinel = pv.UnstructuredGrid()
+    calls = []
+
+    def fake_tetrahedralize_pv(mesh, **kwargs):
+        calls.append((mesh, kwargs))
+        return sentinel
+
+    monkeypatch.setattr("pytetwild.pytetwild.tetrahedralize_pv", fake_tetrahedralize_pv)
+
+    result = sphere.tetwild.tetrahedralize(edge_length_fac=1.0, optimize=False)
+
+    assert result is sentinel
+    assert len(calls) == 1
+    mesh_arg, kwargs_arg = calls[0]
+    assert mesh_arg is sphere
+    assert kwargs_arg == {"edge_length_fac": 1.0, "optimize": False}
 
 
 def test_chains_with_core_filters():


### PR DESCRIPTION
PyVista 0.48 added a dataset-accessor registry (`register_dataset_accessor`) and a `pyvista.accessors` entry-point group for third-party packages to extend its dataset classes. This registers a `.tetwild` namespace on `PolyData` so a surface mesh can be tetrahedralized in a chained call:

```python
import pyvista as pv
import pytetwild  # noqa: F401

grid = pv.Icosphere(nsub=2).tetwild.tetrahedralize(edge_length_fac=0.1)
```

`.tetwild.tetrahedralize` is a thin wrapper over `tetrahedralize_pv` and forwards all keyword arguments.

- Registered two ways: via the `pyvista.accessors` entry point (PyVista loads it when scanning plugins) and via an explicit import in `pytetwild.__init__`, so plain `import pytetwild` also attaches the accessor.
- Scoped to `PolyData` because fTetWild consumes a triangulated surface.
- No-op on pyvista < 0.48 (registry absent); accessor tests skip there. Requires pyvista >= 0.48.
- Delegation is asserted with `monkeypatch` instead of comparing the output of two `tetrahedralize` runs, because fTetWild is non-deterministic across independent runs.