### PR TITLE
ci: drop deprecated flaky macos-15-intel runner

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, windows-2025, macos-latest, macos-15-intel]
+        os: [ubuntu-24.04, windows-2025, macos-latest]
 
     steps:
       - uses: actions/checkout@v6
@@ -64,7 +64,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.13'] # , '3.14']  # skip 3.14 testing until vtk 9.6 is released
-        os: [ubuntu-24.04, windows-2025, macos-15-intel]  # must match build_wheels os
+        os: [ubuntu-24.04, windows-2025, macos-latest]  # must match build_wheels os
     steps:
     - uses: actions/checkout@v6
     - uses: actions/setup-python@v6


### PR DESCRIPTION
GitHub's Intel macOS runners are deprecated and the `macos-15-intel` leg flakes on transient DNS failures during the cibuildwheel install (e.g. run 25328383052). Drops it from the `build_wheels` and `test_abi3` matrices; `test_abi3` now uses `macos-latest` so its OS list still matches `build_wheels`.