### PR TITLE
Build and publish Linux aarch64 wheels

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, windows-2025, macos-latest]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2025, macos-latest]
 
     steps:
       - uses: actions/checkout@v6
@@ -64,7 +64,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.13'] # , '3.14']  # skip 3.14 testing until vtk 9.6 is released
-        os: [ubuntu-24.04, windows-2025, macos-latest]  # must match build_wheels os
+        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2025, macos-latest]  # must match build_wheels os
     steps:
     - uses: actions/checkout@v6
     - uses: actions/setup-python@v6

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,9 +29,11 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ./src/pytetwild)
 # Set the path to the fTetWild project
 set(fTetWild_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src/fTetWild")
 
-# Enable aggressive optimization
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3")
-set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} -O3")
+# Enable aggressive optimization. -fsigned-char keeps `char` signed on
+# aarch64 (where it defaults to unsigned); fTetWild stores -1 sentinels
+# in std::array<char, 4>, which is only valid with signed char.
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -fsigned-char")
+set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} -O3 -fsigned-char")
 
 # Include the fTetWild project as a subdirectory
 add_subdirectory(${fTetWild_DIR} EXCLUDE_FROM_ALL)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,9 @@ test-command = "pytest {project}/tests -v"
 manylinux-x86_64-image = "manylinux2014"
 manylinux-aarch64-image = "manylinux2014"
 before-all = "yum install -y gmp-devel"
-before-build = "pip install abi3audit cmake"
+# On aarch64, point fTetWild's vendored geogram at its aarch64
+# platform file; the default Linux64-gcc one injects x86-only -m64.
+before-build = "pip install abi3audit cmake && if [ $(uname -m) = aarch64 ]; then sed -i 's|VORPALINE_PLATFORM Linux64-gcc |VORPALINE_PLATFORM Linux64-gcc-aarch64 |' src/fTetWild/cmake/geogram.cmake; fi"
 repair-wheel-command = [
   "auditwheel repair -w {dest_dir} {wheel}",
   "bash tools/audit_wheel.sh {wheel}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ test-command = "pytest {project}/tests -v"
 
 [tool.cibuildwheel.linux]
 manylinux-x86_64-image = "manylinux2014"
+manylinux-aarch64-image = "manylinux2014"
 before-all = "yum install -y gmp-devel"
 before-build = "pip install abi3audit cmake"
 repair-wheel-command = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,11 @@ build = "cp310-* cp311-* cp312-*"  # 3.12+ are abi3 wheels
 skip = ["*musllinux*"]  # disable musl-based wheels
 test-extras = ["tests"]
 test-command = "pytest {project}/tests -v"
+# vtk (via pyvista) ships no manylinux2014 aarch64 wheel, so the
+# in-container test env cannot resolve test deps. The aarch64 wheel
+# still builds here; it is exercised by the separate test_abi3 job
+# on a native arm runner with a modern pip environment.
+test-skip = "*-manylinux_aarch64"
 
 [tool.cibuildwheel.linux]
 manylinux-x86_64-image = "manylinux2014"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,8 +65,8 @@ manylinux-x86_64-image = "manylinux2014"
 manylinux-aarch64-image = "manylinux2014"
 before-all = "yum install -y gmp-devel"
 # On aarch64, point fTetWild's vendored geogram at its aarch64
-# platform file; the default Linux64-gcc one injects x86-only -m64.
-before-build = "pip install abi3audit cmake && if [ $(uname -m) = aarch64 ]; then sed -i 's|VORPALINE_PLATFORM Linux64-gcc |VORPALINE_PLATFORM Linux64-gcc-aarch64 |' src/fTetWild/cmake/geogram.cmake; fi"
+# platform; the default Linux64-gcc one injects x86-only -m64.
+before-build = "pip install abi3audit cmake && if [ $(uname -m) = aarch64 ]; then sed -i 's|GEO_PLATFORM \"Linux64-gcc\"|GEO_PLATFORM \"Linux64-gcc-aarch64\"|' src/fTetWild/cmake/FloatTetwildDependencies.cmake; fi"
 repair-wheel-command = [
   "auditwheel repair -w {dest_dir} {wheel}",
   "bash tools/audit_wheel.sh {wheel}"


### PR DESCRIPTION
`pip install pytetwild` on Linux aarch64 has no prebuilt wheel, so pip falls back to a source build of the vendored fTetWild. That build hard-fails at CMake configure with `Cannot find GMP` because the user's environment has no system GMP. Resolves #36.

Builds aarch64 wheels in CI so aarch64 users install a prebuilt wheel and never hit the source build.

- Adds `ubuntu-24.04-arm` to the `build_wheels` and `test_abi3` matrices and pins `manylinux-aarch64-image = manylinux2014`. The existing `before-all` GMP install runs inside the aarch64 container, and `auditwheel repair` produces portable `linux_aarch64` wheels.
- fTetWild's vendored geogram selects the `Linux64-gcc` platform, whose config injects x86-only `-m64`. g++ on aarch64 rejects `-m64`, so the geogram compile fails even once GMP is found. geogram already ships a clean `Linux64-gcc-aarch64` platform, but fTetWild force-sets the cache so a CMake-side override does not stick. The `before-build` step rewrites fTetWild's geogram dependency config to select the aarch64 platform, guarded by `uname -m` so x86 builds are untouched.
- `char` defaults to unsigned on aarch64. fTetWild stores -1 sentinels in `std::array<char, 4>`, which is only valid with signed `char`, so the build needs `-fsigned-char` added to the compile flags.
- `vtk` (a `pyvista` dependency) ships no manylinux2014 aarch64 wheel, so cibuildwheel's in-container test environment cannot resolve the test extras and pip backtracks `pyvista` to an unbuildable ancient sdist. The aarch64 wheel itself builds and is exercised by the `test_abi3` job on a native arm runner with a modern pip environment, so `test-skip` skips only the redundant in-container test for aarch64.
- The release job already globs every wheel artifact, so the new wheels publish to PyPI without further change.