### PR TITLE
ci: set least-privilege GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os }}


### PR DESCRIPTION
CodeQL flagged three open code-scanning alerts (`actions/missing-workflow-permissions`), one per job in `build-and-deploy.yml`: `build_wheels`, `test_abi3`, `build_sdist`. None set explicit `GITHUB_TOKEN` permissions, so they inherit the repository default, which can be read-write.

Adds a top-level `permissions: contents: read`. The three flagged jobs only checkout and handle artifacts, so read is enough. The `release` job keeps its own block (`id-token: write`, `contents: write`), so trusted publishing and release creation are unaffected.

Resolves the three open alerts once CodeQL re-scans `main` after merge.