### PR TITLE
ci: bound import/collection hangs so they fail fast not at the 6h ceiling

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -63,6 +63,10 @@ jobs:
     name: Test ABI3 wheels
     needs: build_wheels
     runs-on: ${{ matrix.os }}
+    # Hard CI guard. Without this a collection/import deadlock burns the
+    # full 6h GitHub ceiling (see macos-latest, run 25986384224). pytest's
+    # session_timeout should fire well before this and dump a stack.
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
@@ -91,11 +95,17 @@ jobs:
         python tools/extract-deps.py
         pip install -r requirements-tests.txt
     - name: Run tests
-      run: pytest
+      # -v -s + faulthandler so an import/collection hang streams progress
+      # and dumps a thread stack instead of going silent for hours.
+      env:
+        PYTHONFAULTHANDLER: '1'
+        PYTHONUNBUFFERED: '1'
+      run: pytest -v -s
 
   build_sdist:
     name: Build source distribution
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,15 @@ testpaths = 'tests'
 # 6h CI ceiling. Method is left to pytest-timeout: signal on POSIX
 # (can interrupt the C extension), thread on Windows (no SIGALRM).
 timeout = 300
+# `timeout` is per-test and only arms once collection finishes, so an
+# import/collection deadlock (seen on macOS arm64: zero pytest output
+# for the full 6h ceiling) slips past it. `session_timeout` bounds the
+# whole run including collection/import and dumps every thread's
+# traceback on expiry, giving the actual hang location.
+session_timeout = 900
+# Belt-and-braces: pytest's faulthandler dumps all-thread tracebacks
+# if anything (incl. interpreter startup work) blocks this long.
+faulthandler_timeout = 600
 
 [tool.cibuildwheel]
 archs = ["auto64"]  # 64-bit only


### PR DESCRIPTION
\`Test ABI3 wheels (3.13, macos-latest)\` in [run 25986384224](https://github.com/pyvista/pytetwild/actions/runs/25986384224/job/76385928422) ran the full 6h GitHub ceiling with zero pytest output. The hang is at import/collection on macOS arm64, before any test runs.

The existing \`timeout = 300\` is pytest-timeout per-test. It only arms after collection finishes, so an import deadlock never triggers it, and no job had a \`timeout-minutes\`, so the run burned to the 6h hard limit.

This adds guards so the same hang fails in minutes and produces a stack instead of going silent:

- \`session_timeout = 900\` and \`faulthandler_timeout = 600\` in the pytest config: bound the whole session including collection/import and dump every thread's traceback on expiry.
- \`timeout-minutes\` on the \`test_abi3\` (25) and \`build_sdist\` (20) jobs as a hard backstop.
- \`pytest -v -s\` with \`PYTHONFAULTHANDLER=1\` / \`PYTHONUNBUFFERED=1\` in the test step so a hang streams progress and a stack.

Diagnostic, not a root-cause fix: the macOS arm64 import deadlock itself is still unknown. The prior run produced no stack; the next macos-latest run will fail in ~15min and dump the hang location to nail it.