### PR TITLE
Resolve VTK through PyVista and store the tets fixed width

### DIFF
--- a/src/pytetwild/pytetwild.py
+++ b/src/pytetwild/pytetwild.py
@@ -50,14 +50,15 @@ def _ugrid_from_regular_cells(
     """
     try:
         import pyvista.core as pv
-    except:
+
+        # PyVista chooses the VTK build -- stock vtkmodules or the cvista fork
+        # -- and arrays from the other one are a foreign type to the grid they
+        # are handed to, so take these names from whichever it selected.
+        from pyvista._vtk import numpy_to_vtk, vtkCellArray, vtkTypeInt32Array
+    except ImportError as exc:
         raise ModuleNotFoundError(
             "Install PyVista to use this feature with:\n\npip install pytetwild[all]"
-        )
-
-    from vtkmodules.vtkCommonCore import vtkTypeInt32Array
-    from vtkmodules.util.numpy_support import numpy_to_vtk
-    from vtkmodules.vtkCommonDataModel import vtkCellArray
+        ) from exc
 
     if cells.ndim != 2:
         raise ValueError("cells must be 2D")
@@ -67,12 +68,15 @@ def _ugrid_from_regular_cells(
 
     n_cells, n_nodes_per_cell = cells.shape
     vtk_dtype = vtkTypeInt32Array().GetDataType()
-    offsets = np.arange(0, n_cells * n_nodes_per_cell + 1, n_nodes_per_cell, dtype=np.int32)
-    offsets_vtk = numpy_to_vtk(offsets, deep=False, array_type=vtk_dtype)
     conn_vtk = numpy_to_vtk(cells.ravel(), deep=False, array_type=vtk_dtype)
 
+    # Every cell here is the same width, so VTK 9.6.2 can hold that one width
+    # instead of an offset per cell and synthesize the offsets on demand. That
+    # is an (n_cells + 1) int32 array we no longer build or keep.
     cell_array = vtkCellArray()
-    cell_array.SetData(offsets_vtk, conn_vtk)
+    if not cell_array.SetData(n_nodes_per_cell, conn_vtk):
+        offsets = np.arange(0, n_cells * n_nodes_per_cell + 1, n_nodes_per_cell, dtype=np.int32)
+        cell_array.SetData(numpy_to_vtk(offsets, deep=False, array_type=vtk_dtype), conn_vtk)
 
     if n_nodes_per_cell == 4:
         cell_type = VTK_TETRA

--- a/tests/test_pytetwild.py
+++ b/tests/test_pytetwild.py
@@ -2,10 +2,10 @@ import sys
 import math
 from typing import Callable
 import os
+import importlib
 import numpy as np
 from numpy.typing import NDArray
 import pyvista as pv
-import vtk
 from scipy.spatial import KDTree
 import pytest
 from pytetwild import tetrahedralize_pv, tetrahedralize, tetrahedralize_csg
@@ -84,8 +84,33 @@ def test_tetrahedralize(mesh_generator: Callable):
     assert len(tetrahedra_result) > 0, "There should be more than 0 tetrahedra in the result"
 
 
+def _vtk_class(name: str, module: str):
+    """Return a VTK class from the build PyVista selected.
+
+    PyVista may sit on stock ``vtkmodules`` or on the ``cvista`` fork, which
+    exposes its classes off the package root. A filter from the build PyVista
+    is not using rejects the meshes PyVista hands it.
+
+    Skips the calling test when the selected build does not ship the class:
+    cvista trims parts of VTK that stock ships, so a name present in one is
+    not guaranteed in the other.
+    """
+    from pyvista import _vtk
+
+    root = getattr(_vtk, "_VTK_ROOT", "vtkmodules")
+    if getattr(_vtk, "_VTK_ROOT_IS_FLAT", False):
+        owner = importlib.import_module(root)
+    else:
+        owner = importlib.import_module(f"{root}.{module}")
+
+    try:
+        return getattr(owner, name)
+    except AttributeError:
+        pytest.skip(f"{root} does not ship {name}")
+
+
 def _sample_points_vtk(mesh_pv: pv.PolyData, dist_btw_pts: float = 0.01) -> NDArray[np.float64]:
-    point_sampler = vtk.vtkPolyDataPointSampler()
+    point_sampler = _vtk_class("vtkPolyDataPointSampler", "vtkFiltersModeling")()
     point_sampler.SetInputData(mesh_pv)
     point_sampler.SetDistance(dist_btw_pts)
     point_sampler.SetPointGenerationMode(point_sampler.REGULAR_GENERATION)
@@ -168,3 +193,20 @@ def test_disable_filtering() -> None:
 
     assert np.isclose(vol_wo_background, 1.0, rtol=0.01)
     assert vol_with_background > 1.1
+
+
+def test_ugrid_from_regular_cells_fixed_width() -> None:
+    """Cells of one width are stored without an offset array."""
+    from pytetwild.pytetwild import _ugrid_from_regular_cells
+
+    rng = np.random.default_rng(0)
+    points = rng.random((40, 3))
+    tets = rng.integers(0, 40, size=(25, 4)).astype(np.int32)
+
+    grid = _ugrid_from_regular_cells(points, tets)
+
+    assert grid.GetCells().IsStorageFixedSize()
+    assert grid.n_cells == 25
+    # the offsets VTK synthesizes have to match the ones we no longer build
+    assert np.array_equal(grid.offset, np.arange(0, 26 * 4, 4))
+    assert np.array_equal(grid.cells_dict[10], tets)


### PR DESCRIPTION
### Overview

`_ugrid_from_regular_cells` built its cell array from `vtkmodules` but took the grid from PyVista. On the `cvista` fork those are two different VTKs, so it fails with `TypeError: arguments do not match any overloaded methods`. This PR takes those names from `pyvista._vtk` so they follow whatever PyVista selected.

Every cell here is the same width, so VTK 9.6.2 can store that one width instead of an offset per cell. The `(n_cells + 1)` offsets array is gone.

The suite reached `vtkPolyDataPointSampler` through a plain `import vtk`, same problem. cvista doesn't ship that class, so that one test skips there and keeps its coverage on stock VTK.

Changes drafted by Claude Opus 5 but fully understood by me
