### PR TITLE
Test the wheels on the runner, not inside manylinux2014

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -85,10 +85,14 @@ jobs:
         python-version: ['3.10', '3.11', '3.13'] # , '3.14']  # skip 3.14 testing until vtk 9.6 is released
         os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2022, macos-15]  # must match build_wheels os
         exclude:
-          # The cp311 macOS arm64 wheel hangs inside fTetWild on the first
-          # tetrahedralize call and gets killed by the job guard. Pre-existing,
-          # and only visible now that this job covers more than the abi3 wheel.
-          # Drop this once #47 is fixed.
+          # macOS runs the abi3 wheel only, which is the coverage this job
+          # always had. tetrahedralize intermittently never returns there and
+          # the guard kills the cell at 25 minutes -- it moves between Python
+          # versions run to run, so it is the platform rather than a wheel.
+          # Pre-existing, and only visible now that this job covers more than
+          # 3.13. Restore these once #47 is fixed.
+          - os: macos-15
+            python-version: '3.10'
           - os: macos-15
             python-version: '3.11'
     steps:

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -48,24 +48,6 @@ jobs:
           echo "GMP_INC=C:\Miniconda\envs\test\Library\include" >> ${env:GITHUB_ENV}
           echo "GMP_LIB=C:\Miniconda\envs\test\Library\lib" >> ${env:GITHUB_ENV}
 
-      - name: Diagnose Visual Studio detection (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        continue-on-error: true
-        run: |
-          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-          Write-Host "vswhere present: $(Test-Path $vswhere)"
-          if (Test-Path $vswhere) {
-            Write-Host "--- all instances ---"
-            & $vswhere -all -prerelease -products * -format value -property installationPath
-            Write-Host "--- with VC tools (what CMake needs) ---"
-            & $vswhere -all -prerelease -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -format value -property installationPath
-          }
-          Write-Host "--- _Instances ---"
-          Get-ChildItem "$env:ProgramData\Microsoft\VisualStudio\Packages\_Instances" -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Name
-          Write-Host "--- env of interest ---"
-          Get-ChildItem env: | Where-Object { $_.Name -match 'CONDA|VS[0-9]|VSINSTALL|VCINSTALL|ProgramData|ProgramFiles|APPDATA|CMAKE' } | Format-Table -AutoSize
-
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.3.1
         env:

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -22,7 +22,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2025, macos-latest]
+        # macos-15, not macos-latest: latest is macOS 26 now, and its
+        # homebrew libgmp bottle declares a 26.0 minimum, which delocate
+        # rejects against the 15.0 target the wheels are tagged with.
+        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2025, macos-15]
 
     steps:
       - uses: actions/checkout@v6
@@ -73,7 +76,7 @@ jobs:
         # one per wheel cibuildwheel produces: cp310 and cp311 are version
         # specific, 3.13 picks up the abi3 wheel built by cp312
         python-version: ['3.10', '3.11', '3.13'] # , '3.14']  # skip 3.14 testing until vtk 9.6 is released
-        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2025, macos-latest]  # must match build_wheels os
+        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2025, macos-15]  # must match build_wheels os
     steps:
     - uses: actions/checkout@v6
     - uses: actions/setup-python@v6

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -48,6 +48,24 @@ jobs:
           echo "GMP_INC=C:\Miniconda\envs\test\Library\include" >> ${env:GITHUB_ENV}
           echo "GMP_LIB=C:\Miniconda\envs\test\Library\lib" >> ${env:GITHUB_ENV}
 
+      - name: Diagnose Visual Studio detection (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        continue-on-error: true
+        run: |
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          Write-Host "vswhere present: $(Test-Path $vswhere)"
+          if (Test-Path $vswhere) {
+            Write-Host "--- all instances ---"
+            & $vswhere -all -prerelease -products * -format value -property installationPath
+            Write-Host "--- with VC tools (what CMake needs) ---"
+            & $vswhere -all -prerelease -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -format value -property installationPath
+          }
+          Write-Host "--- _Instances ---"
+          Get-ChildItem "$env:ProgramData\Microsoft\VisualStudio\Packages\_Instances" -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Name
+          Write-Host "--- env of interest ---"
+          Get-ChildItem env: | Where-Object { $_.Name -match 'CONDA|VS[0-9]|VSINSTALL|VCINSTALL|ProgramData|ProgramFiles|APPDATA|CMAKE' } | Format-Table -AutoSize
+
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.3.1
         env:

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -22,10 +22,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # macos-15, not macos-latest: latest is macOS 26 now, and its
-        # homebrew libgmp bottle declares a 26.0 minimum, which delocate
-        # rejects against the 15.0 target the wheels are tagged with.
-        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2025, macos-15]
+        # Neither windows nor macos can use the -latest image:
+        #
+        # windows-2025 now carries Visual Studio 18, whose toolset dropped
+        # <hash_map>. geogram v1.9.6 still includes it from
+        # third_party/PoissonRecon/Hash.h under _MSC_VER, so it cannot
+        # compile there. windows-2022 keeps VS 2022 until geogram is bumped.
+        #
+        # macos-latest is macOS 26, and its homebrew libgmp bottle declares a
+        # 26.0 minimum, which delocate rejects against the 15.0 target the
+        # wheels are tagged with.
+        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2022, macos-15]
 
     steps:
       - uses: actions/checkout@v6
@@ -76,7 +83,7 @@ jobs:
         # one per wheel cibuildwheel produces: cp310 and cp311 are version
         # specific, 3.13 picks up the abi3 wheel built by cp312
         python-version: ['3.10', '3.11', '3.13'] # , '3.14']  # skip 3.14 testing until vtk 9.6 is released
-        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2025, macos-15]  # must match build_wheels os
+        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2022, macos-15]  # must match build_wheels os
     steps:
     - uses: actions/checkout@v6
     - uses: actions/setup-python@v6

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -84,6 +84,13 @@ jobs:
         # specific, 3.13 picks up the abi3 wheel built by cp312
         python-version: ['3.10', '3.11', '3.13'] # , '3.14']  # skip 3.14 testing until vtk 9.6 is released
         os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2022, macos-15]  # must match build_wheels os
+        exclude:
+          # The cp311 macOS arm64 wheel hangs inside fTetWild on the first
+          # tetrahedralize call and gets killed by the job guard. Pre-existing,
+          # and only visible now that this job covers more than the abi3 wheel.
+          # Drop this once #47 is fixed.
+          - os: macos-15
+            python-version: '3.11'
     steps:
     - uses: actions/checkout@v6
     - uses: actions/setup-python@v6

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -59,8 +59,8 @@ jobs:
           path: ./wheelhouse/*.whl
           name: pytetwild-wheels-${{ matrix.os }}
 
-  test_abi3:
-    name: Test ABI3 wheels
+  test_wheels:
+    name: Test wheels on ${{ matrix.os }} py${{ matrix.python-version }}
     needs: build_wheels
     runs-on: ${{ matrix.os }}
     # Hard CI guard. Without this a collection/import deadlock burns the
@@ -70,7 +70,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.13'] # , '3.14']  # skip 3.14 testing until vtk 9.6 is released
+        # one per wheel cibuildwheel produces: cp310 and cp311 are version
+        # specific, 3.13 picks up the abi3 wheel built by cp312
+        python-version: ['3.10', '3.11', '3.13'] # , '3.14']  # skip 3.14 testing until vtk 9.6 is released
         os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2025, macos-latest]  # must match build_wheels os
     steps:
     - uses: actions/checkout@v6
@@ -81,19 +83,17 @@ jobs:
       with:
         pattern: pytetwild-wheels-${{ matrix.os }}
         path: wheels/
-    - name: Find ABI3 wheel
-      id: find_wheel
-      shell: bash
-      run: |
-        WHEEL=$(ls wheels/*abi3*.whl | head -n 1)
-        echo "wheel=$WHEEL" >> "$GITHUB_OUTPUT"
-    - name: Install wheel
-      run: pip install "${{ steps.find_wheel.outputs.wheel }}"
-    - name: Install test dependencies from source
+        merge-multiple: true
+    - name: Install test dependencies
+      # from the index, so the wheel install below can run offline and
+      # cannot quietly pull pytetwild from PyPI instead of wheels/
       run: |
         pip install tomli
         python tools/extract-deps.py
         pip install -r requirements-tests.txt
+    - name: Install wheel
+      # pip picks the wheel matching this interpreter out of wheels/
+      run: pip install --no-index --find-links wheels/ pytetwild
     - name: Run tests
       # -v -s + faulthandler so an import/collection hang streams progress
       # and dumps a thread stack instead of going silent for hours.
@@ -148,7 +148,7 @@ jobs:
   release:
     name: Release
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
-    needs: [build_wheels, build_sdist]
+    needs: [build_wheels, test_wheels, build_sdist]
     runs-on: ubuntu-latest
     environment:
       name: pypi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,11 @@ repair-wheel-command = [
 ]
 
 [tool.cibuildwheel.windows]
+# CMake picks a generator by probing for Visual Studio, and the 3.29 pinned
+# below does not find the 2022 install on windows-2025. It falls back to
+# NMake Makefiles, which is not on the runner, so the configure step dies on
+# a missing nmake. Name the generator instead of letting it guess.
+environment = {CMAKE_GENERATOR = "Visual Studio 17 2022"}
 before-build = "pip install cmake==3.29.* delvewheel abi3audit && python -c \"import os; file_path = 'build/CMakeCache.txt'; os.remove(file_path) if os.path.exists(file_path) else None\""
 repair-wheel-command = [
   "python -c \"import shutil, os; shutil.copy(os.path.join(os.getenv('GMP_LIB'), '..', 'bin', 'mpir.dll'), '.')\" && delvewheel repair -w {dest_dir} {wheel} --add-path .",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,12 +104,13 @@ repair-wheel-command = [
 ]
 
 [tool.cibuildwheel.windows]
-# CMake picks a generator by probing for Visual Studio, and the 3.29 pinned
-# below does not find the 2022 install on windows-2025. It falls back to
-# NMake Makefiles, which is not on the runner, so the configure step dies on
-# a missing nmake. Name the generator instead of letting it guess.
+# CMake 3.29 cannot see the Visual Studio install on the current
+# windows-2025 image and falls back to NMake Makefiles, which is not on the
+# runner. Nothing in the repo changed between the last green windows build
+# on 2026-06-08 and the first red one, so this is image drift. Track the
+# CMake the image itself ships, staying under 4 for the vendored geogram.
 environment = {CMAKE_GENERATOR = "Visual Studio 17 2022"}
-before-build = "pip install cmake==3.29.* delvewheel abi3audit && python -c \"import os; file_path = 'build/CMakeCache.txt'; os.remove(file_path) if os.path.exists(file_path) else None\""
+before-build = "pip install \"cmake>=3.31,<4\" delvewheel abi3audit && python -c \"import os; file_path = 'build/CMakeCache.txt'; os.remove(file_path) if os.path.exists(file_path) else None\""
 repair-wheel-command = [
   "python -c \"import shutil, os; shutil.copy(os.path.join(os.getenv('GMP_LIB'), '..', 'bin', 'mpir.dll'), '.')\" && delvewheel repair -w {dest_dir} {wheel} --add-path .",
   "bash tools/audit_wheel.sh {wheel}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,13 +76,12 @@ archs = ["auto64"]  # 64-bit only
 before-build = "pip install abi3audit"
 build = "cp310-* cp311-* cp312-*"  # 3.12+ are abi3 wheels
 skip = ["*musllinux*"]  # disable musl-based wheels
-test-extras = ["tests"]
-test-command = "pytest {project}/tests -v"
-# vtk (via pyvista) ships no manylinux2014 aarch64 wheel, so the
-# in-container test env cannot resolve test deps. The aarch64 wheel
-# still builds here; it is exercised by the separate test_abi3 job
-# on a native arm runner with a modern pip environment.
-test-skip = "*-manylinux_aarch64"
+# No in-container test. manylinux2014 is old enough that pip finds no
+# wheel for several test dependencies and falls back to building them
+# from source, which fails on the container's missing headers -- pillow
+# wants libjpeg, and vtk has no aarch64 wheel for it at all. The wheels
+# are tested by the test_wheels job instead, on the runner itself, where
+# the whole dependency set resolves as a user's would.
 
 [tool.cibuildwheel.linux]
 manylinux-x86_64-image = "manylinux2014"
@@ -103,7 +102,6 @@ repair-wheel-command = [
   "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}",
   "bash tools/audit_wheel.sh {wheel}"
 ]
-test-command = ""
 
 [tool.cibuildwheel.windows]
 before-build = "pip install cmake==3.29.* delvewheel abi3audit && python -c \"import os; file_path = 'build/CMakeCache.txt'; os.remove(file_path) if os.path.exists(file_path) else None\""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,11 +104,10 @@ repair-wheel-command = [
 ]
 
 [tool.cibuildwheel.windows]
-# Unpinned, as on linux. windows-2025 now ships Visual Studio 18, and only
-# CMake 4.1 and newer carry a generator for it -- older CMake finds no
-# usable instance and falls back to NMake Makefiles, which is not on the
-# runner. Nothing in the repo changed between the last green windows build
-# on 2026-06-08 and the first red one; the image moved off VS 2022.
+# Unpinned, as on linux. The 3.29 pin predated the Visual Studio on the
+# runner and fell back to NMake Makefiles, which is not installed. Nothing
+# in the repo changed between the last green windows build on 2026-06-08
+# and the first red one; the images moved under it.
 before-build = "pip install cmake delvewheel abi3audit && python -c \"import os; file_path = 'build/CMakeCache.txt'; os.remove(file_path) if os.path.exists(file_path) else None\""
 repair-wheel-command = [
   "python -c \"import shutil, os; shutil.copy(os.path.join(os.getenv('GMP_LIB'), '..', 'bin', 'mpir.dll'), '.')\" && delvewheel repair -w {dest_dir} {wheel} --add-path .",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,13 +104,12 @@ repair-wheel-command = [
 ]
 
 [tool.cibuildwheel.windows]
-# CMake 3.29 cannot see the Visual Studio install on the current
-# windows-2025 image and falls back to NMake Makefiles, which is not on the
+# Unpinned, as on linux. windows-2025 now ships Visual Studio 18, and only
+# CMake 4.1 and newer carry a generator for it -- older CMake finds no
+# usable instance and falls back to NMake Makefiles, which is not on the
 # runner. Nothing in the repo changed between the last green windows build
-# on 2026-06-08 and the first red one, so this is image drift. Track the
-# CMake the image itself ships, staying under 4 for the vendored geogram.
-environment = {CMAKE_GENERATOR = "Visual Studio 17 2022"}
-before-build = "pip install \"cmake>=3.31,<4\" delvewheel abi3audit && python -c \"import os; file_path = 'build/CMakeCache.txt'; os.remove(file_path) if os.path.exists(file_path) else None\""
+# on 2026-06-08 and the first red one; the image moved off VS 2022.
+before-build = "pip install cmake delvewheel abi3audit && python -c \"import os; file_path = 'build/CMakeCache.txt'; os.remove(file_path) if os.path.exists(file_path) else None\""
 repair-wheel-command = [
   "python -c \"import shutil, os; shutil.copy(os.path.join(os.getenv('GMP_LIB'), '..', 'bin', 'mpir.dll'), '.')\" && delvewheel repair -w {dest_dir} {wheel} --add-path .",
   "bash tools/audit_wheel.sh {wheel}"


### PR DESCRIPTION
### Overview

Every wheel job had been failing since at least 2026-07-20 (run 29772490569), each for a different reason, and `test_wheels` needs them all so it has not run since 2026-06-08.

Linux: cibuildwheel installed the `tests` extra inside the manylinux2014 container, where pip finds no wheel for some of it and builds from source instead. pillow wants libjpeg and the container does not have it. aarch64 had already hit the same wall from vtk and was carved out with `test-skip`, so the in-container run only covered x86 anyway. Dropped, and `test_wheels` covers it on the runner where the deps resolve like a user's.

Windows: the CMake pin was old enough that it found no usable Visual Studio and fell back to NMake Makefiles, which is not installed. Unpinned, as linux already is. That got as far as `Building for: Visual Studio 18 2026`, and then geogram v1.9.6 does not compile against that toolset, i.e. `PoissonRecon/Hash.h` still includes the removed `<hash_map>` under `_MSC_VER`. windows-2022 keeps VS 2022 until geogram is bumped.

macOS: `macos-latest` is macOS 26 now and its homebrew libgmp declares a 26.0 minimum, which delocate will not put in a wheel tagged for 15.0. Pinned to `macos-15` so the bottles match, rather than raising the target and dropping every macOS below 26.

`test_wheels` now covers every wheel we build instead of only the abi3 one, and `release` needs it, which it did not before. That turned up #47 straight away: `tetrahedralize` intermittently never returns on macOS arm64, about one cell per run, moving between Python versions. It predates this branch and was invisible while only 3.13 ran there, so macOS stays on 3.13 and the other two platforms take the wider coverage.

Changes drafted by Claude Opus 5 but fully understood by me
