### PR TITLE
Build with `-ffp-contract=off` to fix macOS arm64 hang

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -84,17 +84,6 @@ jobs:
         # specific, 3.13 picks up the abi3 wheel built by cp312
         python-version: ['3.10', '3.11', '3.13'] # , '3.14']  # skip 3.14 testing until vtk 9.6 is released
         os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2022, macos-15]  # must match build_wheels os
-        exclude:
-          # macOS runs the abi3 wheel only, which is the coverage this job
-          # always had. tetrahedralize intermittently never returns there and
-          # the guard kills the cell at 25 minutes -- it moves between Python
-          # versions run to run, so it is the platform rather than a wheel.
-          # Pre-existing, and only visible now that this job covers more than
-          # 3.13. Restore these once #47 is fixed.
-          - os: macos-15
-            python-version: '3.10'
-          - os: macos-15
-            python-version: '3.11'
     steps:
     - uses: actions/checkout@v6
     - uses: actions/setup-python@v6

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,8 +32,19 @@ set(fTetWild_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src/fTetWild")
 # Enable aggressive optimization. -fsigned-char keeps `char` signed on
 # aarch64 (where it defaults to unsigned); fTetWild stores -1 sentinels
 # in std::array<char, 4>, which is only valid with signed char.
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -fsigned-char")
-set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} -O3 -fsigned-char")
+#
+# -ffp-contract=off is geogram's own requirement: exact predicates assume
+# every floating point operation rounds, and a fused multiply-add skips
+# one, so both its Linux platform files pass this flag and say why. The
+# Darwin ones never did, which cost nothing while macOS was x86-64, where
+# the baseline ISA has no FMA to contract into, and breaks on arm64, where
+# it does. Without it the walk in Delaunay3d::locate_inexact runs to its
+# 2500-step cycle guard on nearly every point rather than converging in a
+# few, and tetrahedralize runs for minutes instead of seconds. It goes in
+# the global flags rather than on geogram because fTetWild carries its own
+# copy of Shewchuk's predicates.c, which needs it just as much. See #47.
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -fsigned-char -ffp-contract=off")
+set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} -O3 -fsigned-char -ffp-contract=off")
 
 # Include the fTetWild project as a subdirectory
 add_subdirectory(${fTetWild_DIR} EXCLUDE_FROM_ALL)


### PR DESCRIPTION
### Overview

Resolves #47.

geogram's exact predicates assume every floating point operation rounds, and a fused multiply-add skips one. Its Linux platform files pass `-ffp-contract=off` and say why; the Darwin ones never did, which cost nothing while macOS was x86-64, where the baseline ISA has no FMA to contract into, and breaks on arm64 where it does. Without it the walk in `Delaunay3d::locate_inexact` runs to its 2500-step cycle guard on nearly every point rather than converging in a few. That is the whole stack in a `sample` of a hung run, one thread at 100%, so it is a livelock and not a lock.

30 runs of `pv.Icosphere(nsub=1)` at the accessor test's `edge_length_fac=1.0` on an M2: min 7.07s, median 8.09s, max 10.80s. The 0.3.0 wheel on the same machine gave 6.8s, 26.6s, 28.2s, 30.3s, 43.3s, 49.1s and then one still going at 13 minutes when I killed it. The fixed numbers are the linux distribution from the issue (8.17 / 9.08 / 13.82), i.e. macOS is no longer a different distribution.

It is not only the coarse path: at the default `edge_length_fac=0.05` the 0.3.0 wheel still threw a 28.5s outlier in 10 runs where this branch's worst is 0.98s, so users are hitting this and not just CI. The flag is global rather than on the geogram target because fTetWild carries its own copy of Shewchuk's `predicates.c`, which needs it just as much.

The two macOS `test_wheels` cells #46 excluded come back with it. Full suite green locally, 19 passed in 67s.

Changes drafted by Claude Opus 5 but fully understood by me
