### PR TITLE
Add a sizing field input for spatially varying edge length

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,6 +93,36 @@ You can also work with raw arrays. Here's a simple cube that we turn into tetrah
    v_out, tetra = pytetwild.tetrahedralize(vertices, faces, optimize=False)
 
 
+Usage - Sizing Field
+--------------------
+To vary cell size across the mesh rather than using one edge length
+everywhere, pass a background tetrahedral mesh carrying the target edge
+length at each of its points. This is fTetWild's ``--bg-mesh``.
+
+.. code:: py
+
+   import numpy as np
+   import pyvista as pv
+   import pytetwild
+
+   # Background mesh covering the input, refined on one side
+   background = pv.ImageData(
+       dimensions=(5, 5, 5), spacing=(0.3, 0.3, 0.3), origin=(-0.6, -0.6, -0.6)
+   ).to_tetrahedra()
+   background.point_data["target"] = np.where(
+       background.points[:, 0] < 0, 0.04, 0.2
+   )
+
+   mesh = pytetwild.tetrahedralize_pv(
+       pv.Sphere(), sizing_field=background, sizing_field_scalars="target"
+   )
+
+The value at any point is interpolated over the background tetrahedron
+containing it, and anywhere the background mesh does not cover falls back to
+the global ideal edge length. Note this is unrelated to ``disable_filtering``,
+which keeps the internal background mesh fTetWild builds for itself.
+
+
 Usage - Options
 ---------------
 We've surfaced a several parameters to each of our interfaces
@@ -131,6 +161,17 @@ We've surfaced a several parameters to each of our interfaces
         Set log level (0 = most verbose, 6 = minimal output).
     quiet : bool, default: False
         Disable all output. Overrides ``loglevel``.
+    sizing_field : pv.UnstructuredGrid, optional
+        ``tetrahedralize_pv`` only. All-tetrahedral mesh supplying a
+        spatially varying target edge length. Requires ``optimize=True``.
+    sizing_field_scalars : str, optional
+        ``tetrahedralize_pv`` only. Name of the point array on
+        ``sizing_field`` holding the target edge length. Defaults to its
+        active point scalars.
+    bg_vertices, bg_tets, bg_values : np.ndarray, optional
+        ``tetrahedralize`` only. The same sizing field as raw arrays:
+        points ``(n, 3)``, tetrahedra ``(m, 4)``, and the target edge
+        length at each point ``(n,)``.
 
 
 

--- a/src/FTetWildWrapper.cpp
+++ b/src/FTetWildWrapper.cpp
@@ -9,6 +9,7 @@
 #include <floattetwild/TriangleInsertion.h>
 #include <floattetwild/Types.hpp>
 
+#include <memory>
 #include <oneapi/tbb/global_control.h>
 #include <thread>
 
@@ -21,6 +22,7 @@
 
 #include <geogram/api/defs.h>
 #include <geogram/basic/logger.h>
+#include <geogram/mesh/mesh_AABB.h>
 #include <geogram/mesh/mesh_geometry.h>
 #include <geogram/mesh/mesh_io.h>
 #include <geogram/mesh/mesh_reorder.h>
@@ -139,7 +141,10 @@ nb::tuple Tetrahedralize(
     int loglevel,
     bool quiet,
     bool vtk_ordering,
-    bool disable_filtering) {
+    bool disable_filtering,
+    NDArray<double, 2> bg_vertices,
+    NDArray<int, 2> bg_tets,
+    NDArray<double, 1> bg_values) {
     using namespace floatTetWild;
     using namespace Eigen;
     GEO::initialize();
@@ -208,6 +213,96 @@ nb::tuple Tetrahedralize(
 
     if (!params.init(tree.get_sf_diag())) {
         throw std::runtime_error("FTetWildWrapper.cpp: Parameters initialization failed");
+    }
+
+    // Sizing field, from a background tet mesh carrying a target edge length
+    // per vertex. fTetWild declares params.get_sizing_field_value and calls it
+    // from apply_sizingfield(), but never assigns it anywhere -- the lookup
+    // that main.cpp's --bg-mesh implies is commented out in
+    // MeshImprovement.cpp, so setting apply_sizing_field alone would call an
+    // empty std::function. Supply it here, following that original: find the
+    // background tet containing the point and interpolate the target length
+    // over its four vertices. These locals outlive the optimization() call
+    // below, which is the only thing that reads the field.
+    GEO::Mesh bg_mesh;
+    std::unique_ptr<GEO::MeshCellsAABB> bg_tree;
+    Eigen::VectorXd bg_V;
+    Eigen::VectorXi bg_T;
+    Eigen::VectorXd bg_vals;
+    const size_t n_bg_verts = bg_vertices.shape(0);
+    const size_t n_bg_tets = bg_tets.shape(0);
+    if (n_bg_verts > 0 && n_bg_tets > 0) {
+        bg_V.resize(static_cast<Eigen::Index>(n_bg_verts * 3));
+        std::memcpy(bg_V.data(), bg_vertices.data(), n_bg_verts * 3 * sizeof(double));
+        bg_vals.resize(static_cast<Eigen::Index>(n_bg_verts));
+        std::memcpy(bg_vals.data(), bg_values.data(), n_bg_verts * sizeof(double));
+
+        bg_T.resize(static_cast<Eigen::Index>(n_bg_tets * 4));
+        const int *tet_src = bg_tets.data();
+        for (size_t i = 0; i < n_bg_tets * 4; ++i) {
+            if (tet_src[i] < 0 || static_cast<size_t>(tet_src[i]) >= n_bg_verts) {
+                throw std::runtime_error(
+                    "FTetWildWrapper.cpp: sizing field tetrahedron index out of range");
+            }
+            bg_T(static_cast<Eigen::Index>(i)) = tet_src[i];
+        }
+
+        bg_mesh.vertices.create_vertices(static_cast<int>(n_bg_verts));
+        for (size_t i = 0; i < n_bg_verts; ++i) {
+            GEO::vec3 &p = bg_mesh.vertices.point(static_cast<GEO::index_t>(i));
+            for (int j = 0; j < 3; ++j)
+                p[j] = bg_V(static_cast<Eigen::Index>(i * 3 + j));
+        }
+        bg_mesh.cells.create_tets(static_cast<int>(n_bg_tets));
+        for (size_t i = 0; i < n_bg_tets; ++i) {
+            for (int j = 0; j < 4; ++j) {
+                bg_mesh.cells.set_vertex(
+                    static_cast<GEO::index_t>(i),
+                    static_cast<GEO::index_t>(j),
+                    static_cast<GEO::index_t>(bg_T(static_cast<Eigen::Index>(i * 4 + j))));
+            }
+        }
+
+        // The const overload builds the tree indirectly, leaving the mesh
+        // ordering alone, so containing_tet() still returns an index into
+        // bg_T rather than into a permuted copy.
+        const GEO::Mesh &bg_mesh_ref = bg_mesh;
+        bg_tree.reset(new GEO::MeshCellsAABB(bg_mesh_ref));
+
+        params.apply_sizing_field = true;
+        params.V_sizing_field = bg_V;
+        params.T_sizing_field = bg_T;
+        params.values_sizing_field = bg_vals;
+        params.get_sizing_field_value =
+            [&bg_tree, &bg_V, &bg_T, &bg_vals](const floatTetWild::Vector3 &p) -> double {
+            const GEO::index_t t_id = bg_tree->containing_tet(GEO::vec3(p[0], p[1], p[2]));
+            if (t_id == GEO::MeshCellsAABB::NO_TET) {
+                // Outside the background mesh. Zero leaves the point at the
+                // global ideal edge length rather than collapsing it.
+                return 0.0;
+            }
+
+            const Eigen::Index base = static_cast<Eigen::Index>(t_id) * 4;
+            std::array<floatTetWild::Vector3, 4> vs;
+            for (int j = 0; j < 4; ++j) {
+                const Eigen::Index v = bg_T(base + j) * 3;
+                vs[j] = floatTetWild::Vector3(bg_V(v), bg_V(v + 1), bg_V(v + 2));
+            }
+
+            // Barycentric weight of each vertex is the point's distance from
+            // the opposite face over that vertex's distance from it.
+            double value = 0.0;
+            for (int j = 0; j < 4; ++j) {
+                const floatTetWild::Vector3 n =
+                    ((vs[(j + 1) % 4] - vs[j]).cross(vs[(j + 2) % 4] - vs[j])).normalized();
+                const double d = (vs[(j + 3) % 4] - vs[j]).dot(n);
+                if (d == 0)
+                    continue;
+                value +=
+                    std::fabs((p - vs[j]).dot(n) / d) * bg_vals(bg_T(base + (j + 3) % 4));
+            }
+            return value;
+        };
     }
 
     floatTetWild::Logger::init(!params.is_quiet, params.log_path);

--- a/src/pytetwild/PyfTetWildWrapper.pyi
+++ b/src/pytetwild/PyfTetWildWrapper.pyi
@@ -17,6 +17,9 @@ def tetrahedralize_mesh(
     quiet: bool,
     vtk_ordering: bool,
     disable_filtering: bool,
+    bg_vertices: NDArray[np.float64],
+    bg_tets: NDArray[np.int32],
+    bg_values: NDArray[np.float64],
 ) -> tuple[NDArray[np.float64], NDArray[np.int32]]: ...
 def tetrahedralize_csg(
     csg_file: str,

--- a/src/pytetwild/pytetwild.py
+++ b/src/pytetwild/pytetwild.py
@@ -28,6 +28,131 @@ def _check_edge_length(edge_length_fac: float) -> None:
         raise ValueError("Edge length factor must be between 1e-16 and 1.0")
 
 
+def _unpack_sizing_field(
+    sizing_field: "pv.UnstructuredGrid | None",
+    scalars: str | None,
+) -> tuple[NDArray[np.float64] | None, NDArray[np.int32] | None, NDArray[np.float64] | None]:
+    """Split a PyVista sizing field into points, tetrahedra, and values.
+
+    Parameters
+    ----------
+    sizing_field : pv.UnstructuredGrid | None
+        All-tetrahedral background mesh, or ``None`` for no sizing field.
+    scalars : str | None
+        Name of the point array holding the target edge length. ``None``
+        uses the active point scalars.
+
+    Returns
+    -------
+    tuple
+        ``(points, tets, values)``, each ``None`` when ``sizing_field`` is
+        ``None``. Validation of the arrays themselves is left to
+        :func:`_check_sizing_field`.
+
+    """
+    if sizing_field is None:
+        return None, None, None
+
+    import pyvista.core as pv
+
+    if not isinstance(sizing_field, pv.UnstructuredGrid):
+        raise TypeError(
+            f"`sizing_field` must be a pyvista.UnstructuredGrid, got {type(sizing_field)}"
+        )
+
+    cells_by_type = sizing_field.cells_dict
+    if list(cells_by_type) != [VTK_TETRA]:
+        raise ValueError(
+            "`sizing_field` must contain only tetrahedra. Call `.clean()` on a"
+            " tetrahedralized mesh or build one with e.g."
+            " `pyvista.ImageData(...).to_tetrahedra()`."
+        )
+
+    if scalars is None:
+        scalars = sizing_field.point_data.active_scalars_name
+        if not scalars:
+            raise ValueError(
+                "`sizing_field` has no active point scalars. Pass `sizing_field_scalars`"
+                " with the name of the target edge length array."
+            )
+    if scalars not in sizing_field.point_data:
+        raise KeyError(f"`sizing_field` has no point array named {scalars!r}")
+
+    return sizing_field.points, cells_by_type[VTK_TETRA], sizing_field.point_data[scalars]
+
+
+def _check_sizing_field(
+    bg_vertices: NDArray[np.float64] | None,
+    bg_tets: NDArray[np.int32] | None,
+    bg_values: NDArray[np.float64] | None,
+    optimize: bool,
+) -> tuple[NDArray[np.float64], NDArray[np.int32], NDArray[np.float64]]:
+    """Validate a sizing field and return it as the arrays the extension takes.
+
+    Parameters
+    ----------
+    bg_vertices : np.ndarray[np.float64] | None
+        Background mesh points, shape ``(n, 3)``.
+    bg_tets : np.ndarray[np.int32] | None
+        Background mesh tetrahedra, shape ``(m, 4)``.
+    bg_values : np.ndarray[np.float64] | None
+        Target edge length at each background point, shape ``(n,)``.
+    optimize : bool
+        Whether optimization is enabled. fTetWild applies the sizing field
+        from its optimization stage, so a field is silently ignored without
+        it and that is worth an error rather than a surprise.
+
+    Returns
+    -------
+    tuple[np.ndarray, np.ndarray, np.ndarray]
+        Vertices, tetrahedra, and values. All three are empty when no
+        sizing field was given.
+
+    """
+    given = [arr is not None for arr in (bg_vertices, bg_tets, bg_values)]
+    if not any(given):
+        return (
+            np.empty((0, 3), dtype=np.float64),
+            np.empty((0, 4), dtype=np.int32),
+            np.empty(0, dtype=np.float64),
+        )
+    if not all(given):
+        raise ValueError(
+            "`bg_vertices`, `bg_tets`, and `bg_values` must all be given to use a sizing field"
+        )
+    if not optimize:
+        raise ValueError(
+            "A sizing field requires `optimize=True`. fTetWild applies it during "
+            "optimization, so it would have no effect."
+        )
+
+    vertices = np.ascontiguousarray(bg_vertices, dtype=np.float64)
+    tets = np.ascontiguousarray(bg_tets, dtype=np.int32)
+    values = np.ascontiguousarray(bg_values, dtype=np.float64).ravel()
+
+    if vertices.ndim != 2 or vertices.shape[1] != 3:
+        raise ValueError(f"`bg_vertices` must have shape (n, 3), got {vertices.shape}")
+    if tets.ndim != 2 or tets.shape[1] != 4:
+        raise ValueError(f"`bg_tets` must have shape (m, 4), got {tets.shape}")
+    if len(vertices) == 0 or len(tets) == 0:
+        raise ValueError("Sizing field must have at least one point and one tetrahedron")
+    if len(values) != len(vertices):
+        raise ValueError(
+            f"`bg_values` must have one value per point, got {len(values)} "
+            f"for {len(vertices)} points"
+        )
+    if tets.min() < 0 or tets.max() >= len(vertices):
+        raise IndexError(
+            f"`bg_tets` indexes points outside `bg_vertices` (0 to {len(vertices) - 1})"
+        )
+    if not np.isfinite(vertices).all():
+        raise ValueError("`bg_vertices` must be finite")
+    if not np.isfinite(values).all() or values.min() <= 0:
+        raise ValueError("`bg_values` are target edge lengths and must be finite and positive")
+
+    return vertices, tets, values
+
+
 def _ugrid_from_regular_cells(
     points: NDArray[np.float32] | NDArray[np.float64],
     cells: NDArray[np.int32],
@@ -106,6 +231,8 @@ def tetrahedralize_pv(
     loglevel: int = 3,
     quiet: bool = True,
     disable_filtering: bool = False,
+    sizing_field: "pv.UnstructuredGrid | None" = None,
+    sizing_field_scalars: str | None = None,
 ) -> "pv.UnstructuredGrid":
     """
     Convert a PyVista surface mesh to a PyVista unstructured grid.
@@ -146,6 +273,18 @@ def tetrahedralize_pv(
     disable_filtering : bool, default: False
         Disable the filtering of the resulting mesh, and thus keep
         fTetWilds background mesh.
+    sizing_field : pv.UnstructuredGrid, optional
+        All-tetrahedral mesh supplying a spatially varying target edge
+        length, so some regions come out finer than others. The value at any
+        point is interpolated over the containing tetrahedron; anywhere this
+        mesh does not cover falls back to the global ideal edge length.
+        Requires ``optimize=True``. This is fTetWild's ``--bg-mesh``, and is
+        unrelated to ``disable_filtering``, which keeps the internal
+        background mesh fTetWild builds for itself.
+    sizing_field_scalars : str, optional
+        Name of the point array on ``sizing_field`` holding the target edge
+        length, in the same units as the input. Defaults to its active point
+        scalars.
 
     Returns
     -------
@@ -184,6 +323,9 @@ def tetrahedralize_pv(
         )
         mesh = mesh.triangulate()
     _check_edge_length(edge_length_fac)
+    bg_v, bg_t, bg_val = _check_sizing_field(
+        *_unpack_sizing_field(sizing_field, sizing_field_scalars), optimize=optimize
+    )
 
     if edge_length_abs is None:
         edge_length_abs = 0.0
@@ -214,6 +356,9 @@ def tetrahedralize_pv(
         quiet,
         vtk_ordering,
         disable_filtering,
+        bg_v,
+        bg_t,
+        bg_val,
     )
     return _ugrid_from_regular_cells(tmesh_v, tmesh_c)
 
@@ -234,6 +379,9 @@ def tetrahedralize(
     quiet: bool = True,
     vtk_ordering: bool = False,
     disable_filtering: bool = False,
+    bg_vertices: NDArray[np.float64] | None = None,
+    bg_tets: NDArray[np.int32] | None = None,
+    bg_values: NDArray[np.float64] | None = None,
 ) -> tuple[NDArray[np.float64], NDArray[np.int32]]:
     """
     Convert mesh vertices and faces to a tetrahedral mesh.
@@ -277,6 +425,19 @@ def tetrahedralize(
     disable_filtering : bool, default: False
         Disable the filtering of the resulting mesh, and thus keep
         fTetWilds background mesh.
+    bg_vertices : np.ndarray[np.float64], optional
+        Points of a background tetrahedral mesh supplying a spatially
+        varying target edge length, shape ``(n, 3)``. Give all three
+        ``bg_`` arguments together, and see ``bg_values``.
+    bg_tets : np.ndarray[np.int32], optional
+        Tetrahedra of the background mesh, shape ``(m, 4)``, indexing
+        ``bg_vertices``.
+    bg_values : np.ndarray[np.float64], optional
+        Target edge length at each background point, shape ``(n,)``, in the
+        same units as the input. The value at any point is interpolated over
+        the containing background tetrahedron; anywhere the background mesh
+        does not cover falls back to the global ideal edge length. Requires
+        ``optimize=True``.
 
     Returns
     -------
@@ -284,6 +445,7 @@ def tetrahedralize(
         A tuple containing the vertices and tetrahedra of the tetrahedral mesh.
     """
     _check_edge_length(edge_length_fac)
+    bg_v, bg_t, bg_val = _check_sizing_field(bg_vertices, bg_tets, bg_values, optimize=optimize)
     if not isinstance(vertices, np.ndarray):
         raise TypeError("`vertices` must be a numpy array")
     if not isinstance(faces, np.ndarray):
@@ -315,6 +477,9 @@ def tetrahedralize(
         quiet,
         vtk_ordering,
         disable_filtering,
+        bg_v,
+        bg_t,
+        bg_val,
     )
 
 

--- a/tests/test_sizing_field.py
+++ b/tests/test_sizing_field.py
@@ -1,0 +1,210 @@
+"""Tests for the input sizing field (fTetWild's ``--bg-mesh``)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pyvista as pv
+import pytest
+
+from pytetwild import tetrahedralize, tetrahedralize_pv
+
+# Sphere of diameter 1, so a bounding box diagonal of about 1.73 and a
+# default ideal edge length of about 0.087.
+FINE = 0.04
+COARSE = 0.2
+
+# Ratio of mean cell volume between the coarse and fine halves. Over 5 runs
+# each this is 0.94-1.04 with no sizing field and 3.88-4.13 with one, so 2.5
+# separates them with room for fTetWild's run to run variation. An ignored
+# field lands at 1.0 and cannot reach it.
+MIN_RATIO = 2.5
+
+
+def _background(fine_below_x: float = 0.0, x_min: float = -0.6) -> pv.UnstructuredGrid:
+    """Build a background mesh that asks for fine cells at low x.
+
+    Parameters
+    ----------
+    fine_below_x : float, default: 0.0
+        Points below this x get ``FINE``, the rest get ``COARSE``.
+    x_min : float, default: -0.6
+        Lower x bound of the background mesh. Raise it to leave part of the
+        input uncovered.
+
+    Returns
+    -------
+    pv.UnstructuredGrid
+        All-tetrahedral mesh with a ``target`` point array.
+
+    """
+    n = 5
+    spacing = (0.6 - x_min) / (n - 1)
+    grid = pv.ImageData(
+        dimensions=(n, n, n),
+        spacing=(spacing, 1.2 / (n - 1), 1.2 / (n - 1)),
+        origin=(x_min, -0.6, -0.6),
+    )
+    bg = grid.to_tetrahedra()
+    bg.clear_data()
+    bg.point_data["target"] = np.where(bg.points[:, 0] < fine_below_x, FINE, COARSE)
+    return bg
+
+
+def _mean_volume_by_side(grid: pv.UnstructuredGrid) -> tuple[float, float]:
+    """Return mean cell volume for x < 0 and x > 0.
+
+    Parameters
+    ----------
+    grid : pv.UnstructuredGrid
+        Tetrahedral mesh to measure.
+
+    Returns
+    -------
+    tuple[float, float]
+        Mean cell volume below and above ``x = 0``.
+
+    """
+    sized = grid.compute_cell_sizes(length=False, area=False, volume=True)
+    volume = sized.cell_data["Volume"]
+    left = grid.cell_centers().points[:, 0] < 0
+    assert left.any() and (~left).any(), "both sides must have cells to compare"
+    return volume[left].mean(), volume[~left].mean()
+
+
+def test_sizing_field_refines_the_side_it_asks_for() -> None:
+    """A background mesh asking for small cells at low x produces them."""
+    mesh = pv.Sphere(theta_resolution=20, phi_resolution=20)
+    bg = _background()
+
+    plain_left, plain_right = _mean_volume_by_side(tetrahedralize_pv(mesh, num_opt_iter=5))
+    # Without a field the two halves are the same mesh, so this is the
+    # baseline the assertion below has to beat.
+    assert 0.5 < plain_left / plain_right < 2.0
+
+    sized = tetrahedralize_pv(mesh, num_opt_iter=5, sizing_field=bg, sizing_field_scalars="target")
+    left, right = _mean_volume_by_side(sized)
+    assert right / left > MIN_RATIO, f"expected the low-x half to be finer, got {left=} {right=}"
+
+
+def test_sizing_field_leaves_uncovered_regions_alone() -> None:
+    """Points outside the background mesh keep the global edge length."""
+    mesh = pv.Sphere(theta_resolution=20, phi_resolution=20)
+    # Covers x > -0.1 only, and asks for fine cells across all of it, so the
+    # uncovered low-x side is the one that must stay coarse.
+    bg = _background(fine_below_x=np.inf, x_min=-0.1)
+    bg.point_data["target"] = np.full(bg.n_points, FINE)
+
+    left, right = _mean_volume_by_side(
+        tetrahedralize_pv(mesh, num_opt_iter=5, sizing_field=bg, sizing_field_scalars="target")
+    )
+    assert left / right > MIN_RATIO, f"expected the covered half to be finer, got {left=} {right=}"
+
+
+def test_sizing_field_uses_active_scalars_by_default() -> None:
+    """Omitting ``sizing_field_scalars`` picks up the active point array."""
+    mesh = pv.Sphere(theta_resolution=20, phi_resolution=20)
+    bg = _background()
+    bg.set_active_scalars("target")
+
+    left, right = _mean_volume_by_side(tetrahedralize_pv(mesh, num_opt_iter=5, sizing_field=bg))
+    assert right / left > MIN_RATIO
+
+
+def test_sizing_field_low_level_arrays() -> None:
+    """``tetrahedralize`` accepts the same field as raw arrays."""
+    mesh = pv.Sphere(theta_resolution=20, phi_resolution=20)
+    bg = _background()
+
+    points, cells = tetrahedralize(
+        mesh.points,
+        mesh.faces.reshape(-1, 4)[:, 1:],
+        num_opt_iter=5,
+        vtk_ordering=True,
+        bg_vertices=bg.points,
+        bg_tets=bg.cells_dict[pv.CellType.TETRA],
+        bg_values=bg.point_data["target"],
+    )
+    grid = pv.UnstructuredGrid({pv.CellType.TETRA: cells}, points)
+    left, right = _mean_volume_by_side(grid)
+    assert right / left > MIN_RATIO
+
+
+def test_sizing_field_requires_optimize() -> None:
+    """fTetWild only applies the field while optimizing, so refuse otherwise."""
+    mesh = pv.Sphere(theta_resolution=10, phi_resolution=10)
+    with pytest.raises(ValueError, match="requires `optimize=True`"):
+        tetrahedralize_pv(
+            mesh, optimize=False, sizing_field=_background(), sizing_field_scalars="target"
+        )
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "error", "match"),
+    [
+        ({"bg_vertices": np.zeros((4, 3))}, ValueError, "must all be given"),
+        (
+            {
+                "bg_vertices": np.zeros((4, 3)),
+                "bg_tets": np.zeros((1, 4), np.int32),
+                "bg_values": np.zeros(3),
+            },
+            ValueError,
+            "one value per point",
+        ),
+        (
+            {
+                "bg_vertices": np.zeros((4, 3)),
+                "bg_tets": np.full((1, 4), 9, np.int32),
+                "bg_values": np.ones(4),
+            },
+            IndexError,
+            "outside `bg_vertices`",
+        ),
+        (
+            {
+                "bg_vertices": np.zeros((4, 3)),
+                "bg_tets": np.zeros((1, 4), np.int32),
+                "bg_values": np.zeros(4),
+            },
+            ValueError,
+            "finite and positive",
+        ),
+    ],
+)
+def test_sizing_field_array_validation(kwargs: dict, error: type, match: str) -> None:
+    """Malformed low-level arrays are rejected before reaching the extension."""
+    mesh = pv.Sphere(theta_resolution=10, phi_resolution=10)
+    with pytest.raises(error, match=match):
+        tetrahedralize(mesh.points, mesh.faces.reshape(-1, 4)[:, 1:], **kwargs)
+
+
+def test_sizing_field_rejects_non_tetrahedral_grid() -> None:
+    """The background mesh has to be tetrahedra, which is what fTetWild reads."""
+    mesh = pv.Sphere(theta_resolution=10, phi_resolution=10)
+    hexes = pv.ImageData(dimensions=(3, 3, 3)).cast_to_unstructured_grid()
+    hexes.point_data["target"] = np.full(hexes.n_points, FINE)
+    with pytest.raises(ValueError, match="only tetrahedra"):
+        tetrahedralize_pv(mesh, sizing_field=hexes, sizing_field_scalars="target")
+
+
+def test_sizing_field_rejects_wrong_type() -> None:
+    """A surface mesh is a common mistake and gets a clear message."""
+    mesh = pv.Sphere(theta_resolution=10, phi_resolution=10)
+    with pytest.raises(TypeError, match="must be a pyvista.UnstructuredGrid"):
+        tetrahedralize_pv(mesh, sizing_field=pv.Sphere())
+
+
+def test_sizing_field_missing_scalars() -> None:
+    """A named array that is not there is an error, not a silent default."""
+    mesh = pv.Sphere(theta_resolution=10, phi_resolution=10)
+    with pytest.raises(KeyError, match="no point array named 'nope'"):
+        tetrahedralize_pv(mesh, sizing_field=_background(), sizing_field_scalars="nope")
+
+
+def test_sizing_field_no_active_scalars() -> None:
+    """With nothing active and no name given, say which argument to pass."""
+    mesh = pv.Sphere(theta_resolution=10, phi_resolution=10)
+    bg = _background()
+    bg.set_active_scalars(None)
+    with pytest.raises(ValueError, match="no active point scalars"):
+        tetrahedralize_pv(mesh, sizing_field=bg)


### PR DESCRIPTION
### Overview

Resolves #16.

Exposes fTetWild's `--bg-mesh`, i.e. a background tetrahedral mesh carrying a target edge length at each of its points, so some regions come out finer than others. `tetrahedralize_pv` takes a PyVista `UnstructuredGrid` plus the name of a point array, `tetrahedralize` takes the same thing as three arrays. Anywhere the background mesh does not cover falls back to the global ideal edge length, and it needs `optimize=True` because that is the stage fTetWild applies it from, so passing one without it raises rather than doing nothing.

One thing worth a look, since it is more than the wiring #16 describes: fTetWild declares `params.get_sizing_field_value` and calls it from `apply_sizingfield()`, but never assigns it anywhere. The lookup is commented out in `MeshImprovement.cpp`, so setting `apply_sizing_field` and the three `*_sizing_field` members on their own reaches an empty `std::function`. Upstream `--bg-mesh` looks like it has the same hole. The wrapper supplies the lookup instead, following that commented-out original: find the background tet containing the point with a `GEO::MeshCellsAABB` and interpolate the target length over its four vertices.

Mean cell volume ratio between the two halves of a sphere, over 5 runs each: 0.94-1.04 with no field and 3.88-4.13 with one asking for 0.04 on one side and 0.2 on the other. `tests/test_sizing_field.py` asserts on 2.5 so it sits between them, and the no-field baseline is asserted in the same test, i.e. it fails if the field is ever ignored.

Changes drafted by Claude Opus 5 but fully understood by me
