### PR TITLE
release v0.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["scikit-build-core >=0.4.3", "nanobind >=1.3.2"]
 
 [project]
 name = "pytetwild"
-version = "0.4.dev0"
+version = "0.4.0"
 description = "Python wrapper of fTetWild"
 readme = { file = "README.rst", content-type = "text/x-rst" }
 authors = [{ name = "Alex Kaszynski", email = "akascap@gmail.com" }]


### PR DESCRIPTION
Bumps the version for the 0.4.0 release. Tag goes on the merge commit.

Since 0.3.0: `-ffp-contract=off` so `tetrahedralize` stops hanging on macOS arm64 (#48, resolves #47), and a sizing field input for spatially varying edge length (#49, resolves #16).