### PR TITLE
Derive the version from git tags with setuptools-scm

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -38,6 +38,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true
+          fetch-depth: 0  # required for setuptools-scm to see the tags
 
       - name: Setup Miniconda (Windows)
         if: runner.os == 'Windows'
@@ -120,6 +121,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true
+          fetch-depth: 0  # required for setuptools-scm to see the tags
 
       - name: Install system dependencies
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,5 @@ __opt.stl
 
 # nixos
 shell.nix
+# setuptools-scm writes this at build time
+src/pytetwild/_version.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
 build-backend = "scikit_build_core.build"
-requires = ["scikit-build-core >=0.4.3", "nanobind >=1.3.2"]
+requires = ["scikit-build-core >=0.10", "nanobind >=1.3.2", "setuptools-scm>=8"]
 
 [project]
 name = "pytetwild"
-version = "0.4.0"
+dynamic = ["version"]
 description = "Python wrapper of fTetWild"
 readme = { file = "README.rst", content-type = "text/x-rst" }
 authors = [{ name = "Alex Kaszynski", email = "akascap@gmail.com" }]
@@ -46,6 +46,15 @@ tetwild = "pytetwild._accessor"
 build-dir = "./build"
 editable.mode = "inplace"
 wheel.py-api = "cp312"
+minimum-version = "0.10"
+metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
+# The sdist carries no git history, so ship the generated file for
+# setuptools-scm to fall back to.
+sdist.include = ["src/pytetwild/_version.py"]
+
+[tool.setuptools_scm]
+version_scheme = "release-branch-semver"
+write_to = "src/pytetwild/_version.py"
 
 [tool.scikit-build.cmake]
 args = [

--- a/src/pytetwild/__init__.py
+++ b/src/pytetwild/__init__.py
@@ -1,5 +1,15 @@
 """Wrapper for fTetWild."""
 
-from ._version import __version__  # noqa: F401
 from .pytetwild import tetrahedralize, tetrahedralize_pv, tetrahedralize_csg  # noqa: F401
 from . import _accessor as _accessor
+
+try:
+    # Written by setuptools-scm at build time
+    from ._version import version as __version__
+except ImportError:  # pragma: no cover
+    from importlib.metadata import PackageNotFoundError, version
+
+    try:
+        __version__ = version("pytetwild")
+    except PackageNotFoundError:
+        __version__ = "unknown"

--- a/src/pytetwild/_version.py
+++ b/src/pytetwild/_version.py
@@ -1,5 +1,0 @@
-"""Contains the pytetwild version."""
-
-from importlib import metadata
-
-__version__ = metadata.version("pytetwild")


### PR DESCRIPTION
### Overview

Switches the version to setuptools-scm, following pyvista-miniply: `dynamic = ["version"]`, `metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"`, and `write_to = "src/pytetwild/_version.py"`, so the checked-in `_version.py` goes away and the sdist ships the generated one. The building checkouts need `fetch-depth: 0` or there are no tags to read.

Worth knowing before this merges: **the release tags are not reachable from `main`.** Every release so far was tagged on its own branch commit which was then squash merged, so `v0.3.0` points at `eea46df`, which is not an ancestor of `main`. `git describe` on main finds `0.1.dev1`, and this branch's untagged sdist builds as `0.2.0.dev41+g8321b672`, i.e. below what is already on PyPI. Building at a tag is exact regardless (`v0.4.0` on this tree gives exactly `0.4.0`), and a tag is the only thing that ever gets published, so the release itself is fine. Tagging the merge commit on main rather than a branch commit fixes the dev versions from then on.

Checked locally: sdist at a tag is `pytetwild-0.4.0.tar.gz` and carries `_version.py`, wheel installs with `pytetwild.__version__ == "0.4.0"`, and the suite is green.

Changes drafted by Claude Opus 5 but fully understood by me
