### PR TITLE
Pin the release version to the tag, drop dead sizing field members, update tooling

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -40,6 +40,17 @@ jobs:
           submodules: true
           fetch-depth: 0  # required for setuptools-scm to see the tags
 
+      # The aarch64 before-build seds a tracked file in the fTetWild
+      # submodule, which makes the tree dirty, which makes setuptools-scm
+      # report a .devN+local version even when sitting exactly on a tag.
+      # PyPI rejects local versions, so v0.4.0 published everything except
+      # the aarch64 wheels. Pin the version from the tag instead of the
+      # working tree, which is deterministic whatever a build step touches.
+      - name: Pin the version to the tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: bash
+        run: echo "SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PYTETWILD=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
+
       - name: Setup Miniconda (Windows)
         if: runner.os == 'Windows'
         uses: conda-incubator/setup-miniconda@v3.3.0
@@ -61,6 +72,9 @@ jobs:
         env:
           CIBW_ENVIRONMENT_MACOS: 'MACOSX_DEPLOYMENT_TARGET="15.0"'
           CIBW_ARCHS_MACOS: "auto"
+          # Linux builds run in a container, so the pinned version has to be
+          # handed through explicitly. Unset off a tag, which is fine.
+          CIBW_ENVIRONMENT_PASS_LINUX: SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PYTETWILD
 
       - name: List generated wheels
         run: ls ./wheelhouse/*
@@ -123,6 +137,12 @@ jobs:
           submodules: true
           fetch-depth: 0  # required for setuptools-scm to see the tags
 
+      # Same reasoning as build_wheels: the tag decides the version, not the
+      # state of the working tree.
+      - name: Pin the version to the tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: echo "SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PYTETWILD=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
+
       - name: Install system dependencies
         run: |
           sudo apt-get update
@@ -177,6 +197,11 @@ jobs:
           find . -name '*.tar.gz' -exec mv {} dist/ \;
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # Uploads are per file, so one rejected wheel leaves the release
+          # half published and no re-run can ever get past the files that
+          # already landed. Skipping them lets a re-run fill in the rest.
+          skip-existing: true
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.15.12
+  rev: v0.16.3
   hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]
@@ -14,13 +14,14 @@ repos:
     exclude: README.rst
 
 - repo: https://github.com/numpy/numpydoc
+  # Held at the latest stable; autoupdate picks up v1.11.0rc0 otherwise
   rev: v1.10.0
   hooks:
   - id: numpydoc-validation
     files: ^src/pytetwild
 
 - repo: https://github.com/codespell-project/codespell
-  rev: v2.4.2
+  rev: v2.4.3
   hooks:
   - id: codespell
     args: ["--skip=*.vt*"]
@@ -40,7 +41,7 @@ repos:
   - id: trailing-whitespace
 
 - repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: v22.1.5
+  rev: v22.1.8
   hooks:
   - id: clang-format
     files: |
@@ -49,7 +50,7 @@ repos:
       )$
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v2.0.0
+  rev: v2.3.1
   hooks:
   - id: mypy
     exclude: ^(docs/|tests)
@@ -59,6 +60,6 @@ repos:
   ]
 
 - repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.37.2
+  rev: 0.38.0
   hooks:
     - id: check-github-workflows

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ sdist.include = ["src/pytetwild/_version.py"]
 
 [tool.setuptools_scm]
 version_scheme = "release-branch-semver"
-write_to = "src/pytetwild/_version.py"
+version_file = "src/pytetwild/_version.py"
 
 [tool.scikit-build.cmake]
 args = [
@@ -169,7 +169,14 @@ exclude = [
 ]
 line-length = 100
 indent-width = 4
-target-version = 'py38'
+# Must track requires-python. While this said py38 ruff wanted
+# `from __future__ import annotations` for syntax that is fine on 3.10.
+target-version = 'py310'
+
+[tool.ruff.lint.per-file-ignores]
+# The stub has to be named for the nanobind module it describes, and that
+# name comes from the C++ side.
+"src/pytetwild/PyfTetWildWrapper.pyi" = ["N999"]
 
 [tool.ruff.lint]
 external = ["E131", "D102", "D105"]

--- a/src/FTetWildWrapper.cpp
+++ b/src/FTetWildWrapper.cpp
@@ -269,10 +269,10 @@ nb::tuple Tetrahedralize(
         const GEO::Mesh &bg_mesh_ref = bg_mesh;
         bg_tree.reset(new GEO::MeshCellsAABB(bg_mesh_ref));
 
+        // Only these two matter. The V/T/values_sizing_field members that
+        // main.cpp fills in are read by nothing in fTetWild, so setting them
+        // here would be dead weight.
         params.apply_sizing_field = true;
-        params.V_sizing_field = bg_V;
-        params.T_sizing_field = bg_T;
-        params.values_sizing_field = bg_vals;
         params.get_sizing_field_value =
             [&bg_tree, &bg_V, &bg_T, &bg_vals](const floatTetWild::Vector3 &p) -> double {
             const GEO::index_t t_id = bg_tree->containing_tet(GEO::vec3(p[0], p[1], p[2]));

--- a/src/pytetwild/__init__.py
+++ b/src/pytetwild/__init__.py
@@ -1,7 +1,7 @@
 """Wrapper for fTetWild."""
 
-from .pytetwild import tetrahedralize, tetrahedralize_pv, tetrahedralize_csg  # noqa: F401
 from . import _accessor as _accessor
+from .pytetwild import tetrahedralize, tetrahedralize_csg, tetrahedralize_pv  # noqa: F401
 
 try:
     # Written by setuptools-scm at build time

--- a/src/pytetwild/_accessor.py
+++ b/src/pytetwild/_accessor.py
@@ -14,7 +14,6 @@ from typing import Any
 
 import pyvista as pv
 
-
 HAS_ACCESSOR_REGISTRY = hasattr(pv, "register_dataset_accessor")
 
 

--- a/src/pytetwild/pytetwild.py
+++ b/src/pytetwild/pytetwild.py
@@ -1,10 +1,12 @@
 """Wrapper for fTetWild."""
 
 import warnings
-import numpy as np
-from pytetwild import PyfTetWildWrapper
 from typing import TYPE_CHECKING
+
+import numpy as np
 from numpy.typing import NDArray
+
+from pytetwild import PyfTetWildWrapper
 
 if TYPE_CHECKING:
     import pyvista as pv

--- a/tools/extract-deps.py
+++ b/tools/extract-deps.py
@@ -2,7 +2,8 @@
 
 import tomli
 
-data = tomli.load(open("pyproject.toml", "rb"))
+with open("pyproject.toml", "rb") as f:
+    data = tomli.load(f)
 deps = data["project"]["optional-dependencies"]["tests"]
 with open("requirements-tests.txt", "w") as f:
     f.write("\n".join(deps))


### PR DESCRIPTION
### Overview

Cleanups closing out 0.4.0, plus the release bug that 0.4.0 exposed.

**The release bug.** The aarch64 `before-build` seds a tracked file in the fTetWild submodule to select geogram's aarch64 platform. That leaves the tree dirty, so setuptools-scm reported `0.5.0.dev0+g27ad3115f.d20260816` rather than `0.4.0` while sitting exactly on the tag, and PyPI rejects local versions. Reproduced locally: clean at the tag gives `0.4.0`, the same sed gives `0.4.1.dev0+g27ad3115f.d20260816`. Only aarch64 is guarded by that `if`, which is why every other platform published and aarch64 did not. **0.4.0 on PyPI is nine wheels with no aarch64 and no sdist**, so `pip install pytetwild` fails outright on Linux arm64. Fix is to take the version from the tag, which is deterministic whatever a build step touches, verified by building an sdist on a deliberately dirtied tree and getting `pytetwild-0.4.0.tar.gz`. `skip-existing` goes on the publish step too, since uploads are per file and one rejection otherwise wedges every future re-run.

**Dead members.** `params.V_sizing_field`, `T_sizing_field` and `values_sizing_field` are what `main.cpp` fills in from `--bg-mesh`, but nothing in fTetWild reads them; only `apply_sizing_field` and the `get_sizing_field_value` callback do any work. Suite still green without them, which is the point.

**setuptools-scm.** `write_to` is soft deprecated in v8, so this uses `version_file`.

**pre-commit.** `autoupdate`, holding numpydoc at v1.10.0 because it otherwise picks up the `v1.11.0rc0` pre-release. Ruff's new defaults turned up two real problems rather than noise: `target-version` said `py38` while `requires-python` says `>=3.10`, so it demanded `from __future__ import annotations` for syntax that is fine on 3.10, and `tools/extract-deps.py` leaked a file handle. Import reordering in three `src/` files is ruff's own autofix. `N999` is ignored for the nanobind stub, whose filename has to match the C++ module name.

0.4.1 follows this to get a complete set of artifacts up.

Changes drafted by Claude Opus 5 but fully understood by me
