### PR TITLE
Require pyvista >=0.48

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ pytetwild = ["py.typed"]
 
 [project.optional-dependencies]
 all = ['pyvista']
-tests = ["pytest", "pytest-timeout", "pyvista", "scipy<1.17.0", "meshio"]
+tests = ["pytest", "pytest-timeout", "pyvista>=0.48", "scipy<1.17.0", "meshio"]
 dev = ["pre-commit"]
 
 [project.entry-points."pyvista.accessors"]


### PR DESCRIPTION
Addressing [comment from #45](https://github.com/pyvista/pytetwild/pull/45#issuecomment-5315594003).

> The `pyproject.toml` should be updated to reflect that this change requires `pyvista>=0.48`, as `pyvista._vtk` is not present in 0.47.3, ref:
> 
> https://github.com/pyvista/pyvista/tree/v0.47.3/pyvista
